### PR TITLE
fix: vxnet_name is not a required param

### DIFF
--- a/qingcloud/iaas/connection.py
+++ b/qingcloud/iaas/connection.py
@@ -1059,7 +1059,7 @@ class APIConnection(HttpConnection):
         valid_keys = ['vxnet_name', 'vxnet_type', 'count']
         body = filter_out_none(locals(), valid_keys)
         if not self.req_checker.check_params(body,
-                required_params=['vxnet_name'],
+                required_params=['vxnet_type'],
                 integer_params=['vxnet_type', 'count'],
                 list_params=[]
                 ):


### PR DESCRIPTION
ref: https://docs.qingcloud.com/api/vxnet/create_vxnets.html