### PR TITLE
add default value for vxnet_name to fix Typeerror

### DIFF
--- a/qingcloud/iaas/connection.py
+++ b/qingcloud/iaas/connection.py
@@ -1045,7 +1045,7 @@ class APIConnection(HttpConnection):
 
         return self.send_request(action, body)
 
-    def create_vxnets(self, vxnet_name,
+    def create_vxnets(self, vxnet_name=None,
                             vxnet_type=const.VXNET_TYPE_MANAGED,
                             count=1,
                             **ignore):


### PR DESCRIPTION
Sorry for the trouble, I add default value `None` for `vxnet_name` to avoid Typeerror while use `create_vxnet` without a vxnet_name.