### PR TITLE
[Fix] json.loads() error caused by different response type of http.client and httplib

### DIFF
--- a/qingcloud/qingstor/bucket.py
+++ b/qingcloud/qingstor/bucket.py
@@ -78,13 +78,13 @@ class Bucket(object):
             err = get_response_error(response)
             err.code = "invalid_access_key_id"
             err.message = "Request not authenticated, Access Key ID is either " \
-                          "missing or invalid."
+                "missing or invalid."
             raise err
         elif response.status == 403:
             err = get_response_error(response)
             err.code = "permission_denied"
             err.message = "You don't have enough permission to accomplish " \
-                          "this request."
+                "this request."
             raise err
         elif response.status == 404:
             err = get_response_error(response)

--- a/qingcloud/qingstor/bucket.py
+++ b/qingcloud/qingstor/bucket.py
@@ -20,7 +20,7 @@ from .key import Key
 from .acl import ACL
 from .multipart import MultiPartUpload
 from .exception import get_response_error
-
+from .util import load_data
 
 class Bucket(object):
     DefaultContentType = "application/oct-stream"
@@ -44,18 +44,6 @@ class Bucket(object):
 
     def __len__(self):
         pass
-
-    def load_data(self, response_data):
-        """ Judge the type of data, fix the json.loads error.
-        Returns: JSON data
-
-        Keyword arguments:
-        response_data - Data from response read, may be bytes or str
-        """
-        if type(response_data) == bytes:
-            return json.loads(response_data.decode("utf-8"))
-        else:
-            return json.loads(response_data)
 
     def get_key(self, key_name, validate=True):
         """ Retrieves an object by name.
@@ -140,7 +128,7 @@ class Bucket(object):
         response = self.connection.make_request(
             "GET", self.name, params=params)
         if response.status == 200:
-            resp = self.load_data(response.read())
+            resp = load_data(response.read())
             result_set = []
             for k in resp["keys"]:
                 key = Key(self, k["key"])
@@ -168,7 +156,7 @@ class Bucket(object):
         response = self.connection.make_request(
             "GET", self.name, params=params)
         if response.status == 200:
-            resp = self.load_data(response.read())
+            resp = load_data(response.read())
             return resp
         else:
             err = get_response_error(response)
@@ -181,7 +169,7 @@ class Bucket(object):
         response = self.connection.make_request(
             "GET", self.name, params=params)
         if response.status == 200:
-            resp = self.load_data(response.read())
+            resp = load_data(response.read())
             return ACL(self, resp["acl"])
         else:
             err = get_response_error(response)
@@ -224,7 +212,7 @@ class Bucket(object):
         response = self.connection.make_request(
             "POST", self.name, key_name, headers=headers, params=params)
         if response.status == 200:
-            resp = self.load_data(response.read())
+            resp = load_data(response.read())
             handler = MultiPartUpload(self, key_name, resp["upload_id"])
             return handler
         else:

--- a/qingcloud/qingstor/connection.py
+++ b/qingcloud/qingstor/connection.py
@@ -16,7 +16,6 @@
 
 import os
 import sys
-import json
 import time
 import random
 import urllib
@@ -34,6 +33,7 @@ from qingcloud.conn.connection import HttpConnection, HTTPRequest
 
 from .bucket import Bucket
 from .exception import get_response_error
+from .util import load_data
 
 
 class Zone(object):
@@ -110,7 +110,7 @@ class QSConnection(HttpConnection):
             headers = {}
         response = self.make_request("GET", headers=headers)
         if response.status == 200:
-            return json.loads(response.read())
+            return load_data(response.read())
         else:
             err = get_response_error(response)
             raise err
@@ -273,3 +273,4 @@ class QSConnection(HttpConnection):
                 if retry_time >= self.retry_time - 1:
                     raise
             retry_time += 1
+

--- a/qingcloud/qingstor/exception.py
+++ b/qingcloud/qingstor/exception.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 # =========================================================================
 
-import json
+from .util import load_data
 
 
 class QSResponseError(Exception):
@@ -47,7 +47,7 @@ def get_response_error(response, body=None):
     }
     if body:
         try:
-            resp = json.loads(body)
+            resp = load_data(body)
             args["code"] = resp["code"]
             args["message"] = resp["message"]
             args["url"] = resp["url"]

--- a/qingcloud/qingstor/multipart.py
+++ b/qingcloud/qingstor/multipart.py
@@ -14,9 +14,8 @@
 # limitations under the License.
 # =========================================================================
 
-import json
-
 from .exception import get_response_error
+from .util import load_data
 
 
 class Part(object):
@@ -83,7 +82,7 @@ class MultiPartUpload(object):
             "GET", self.bucket.name, self.key_name, params=params)
         if response.status == 200:
             parts = []
-            resp = json.loads(response.read())
+            resp = load_data(response.read())
             for item in resp["object_parts"]:
                 part = Part(self.bucket.name, self.key_name,
                             item["part_number"])

--- a/qingcloud/qingstor/util.py
+++ b/qingcloud/qingstor/util.py
@@ -1,0 +1,29 @@
+# =========================================================================
+# Copyright 2016 Yunify, Inc.
+# -------------------------------------------------------------------------
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this work except in compliance with the License.
+# You may obtain a copy of the License in the LICENSE file, or at:
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# =========================================================================
+
+import json
+
+def load_data(response_data):
+    """ Wrapper to load json data, to be compatible with Python3.
+    Returns: JSON data
+
+    Keyword arguments:
+    response_data - Data from response read, may be bytes or str
+    """
+    if type(response_data) == bytes:
+        return json.loads(response_data.decode("utf-8"))
+    else:
+        return json.loads(response_data)


### PR DESCRIPTION
`httplib`'s `HTTPResponse.read()` returns `str`, while `http.client`'s `HTTPResponse.read()` returns `bytes`, which caused json.loads() error.

This bug can be reproduced on any version on python3, reproduced code here:

```python
import qingcloud.qingstor

conn = qingcloud.qingstor.connect(
        'pek3a.qingstor.com',
        'abc',
        'def'
    )

bucket = conn.get_bucket('xyz')
print(bucket.stats())
```

This bug can pass unit test normally.