### PR TITLE
Change verb for CreateServerCertificate api

### DIFF
--- a/qingcloud/iaas/connection.py
+++ b/qingcloud/iaas/connection.py
@@ -2560,7 +2560,7 @@ class APIConnection(HttpConnection):
                                              ):
             return None
 
-        return self.send_request(action, body)
+        return self.send_request(action, body, verb='POST')
 
     def describe_server_certificates(self, server_certificates=None,
                                      search_word=None,


### PR DESCRIPTION
`此 API 需使用 POST 方法`

see: https://docs.qingcloud.com/api/lb/create_server_certificate.html