### PR TITLE
Add router_type option to CreateRouters

### DIFF
--- a/qingcloud/iaas/connection.py
+++ b/qingcloud/iaas/connection.py
@@ -1395,15 +1395,17 @@ class APIConnection(HttpConnection):
                        router_name=None,
                        security_group=None,
                        vpc_network=None,
+                       router_type=None,
                        **ignore):
         """ Create one or more routers.
         @param router_name: the name of the router.
         @param security_group: the ID of the security_group you want to apply to router.
         @param count: the count of router you want to create.
         @param vpc_network: VPC IP addresses range, currently support "192.168.0.0/16" or "172.16.0.0/16", required in zone pek3a.
+        @param router_type: 0 - Medium, 1 - Small, 2 - large, 3 - extra-large (default is 1).
         """
         action = const.ACTION_CREATE_ROUTERS
-        valid_keys = ['count', 'router_name', 'security_group', 'vpc_network']
+        valid_keys = ['count', 'router_name', 'security_group', 'vpc_network', 'router_type']
         body = filter_out_none(locals(), valid_keys)
         if not self.req_checker.check_params(body,
                                              required_params=[],


### PR DESCRIPTION
I noticed this option was missing in the python cli/sdk but was available in the API. The documentation needs updating to reference "3 = extra-large" and that it should be passed as a string, not an integer. https://docs.qingcloud.com/api/router/create_routers.html