### PR TITLE
fix get_utf8_value()

### DIFF
--- a/qingcloud/misc/utils.py
+++ b/qingcloud/misc/utils.py
@@ -20,11 +20,14 @@ import base64
 
 
 def get_utf8_value(value):
-    value = str(value)
     if sys.version < "3":
+        if isinstance(value, unicode):
+            return value.encode('utf-8')
+        if not isinstance(value, str):
+            value = str(value)
         return value.encode('utf-8')
     else:
-        return value
+        return str(value)
 
 
 def filter_out_none(dictionary, keys=None):


### PR DESCRIPTION
在python2里，执行`str(u'你好')`会抛出异常。
所以如果`value`已经是`unicode`了，就不要进行转换。