### PR TITLE
fix get_utf8_value()

### DIFF
--- a/qingcloud/misc/utils.py
+++ b/qingcloud/misc/utils.py
@@ -20,11 +20,14 @@ import base64
 
 
 def get_utf8_value(value):
-    value = str(value)
     if sys.version < "3":
-        return value.encode('utf-8')
-    else:
+        if isinstance(value, unicode):
+            return value.encode('utf-8')
+        if not isinstance(value, str):
+            value = str(value)
         return value
+    else:
+        return str(value)
 
 
 def filter_out_none(dictionary, keys=None):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -28,6 +28,7 @@ class UtilsTestCase(unittest.TestCase):
         self.assertEqual(get_utf8_value('utf-8'), 'utf-8')
         self.assertEqual(get_utf8_value(u'unicode'), 'unicode')
         self.assertEqual(get_utf8_value([1, 2]), '[1, 2]')
+        self.assertEqual(get_utf8_value(u'\u4f60\u597d'), '\xe4\xbd\xa0\xe5\xa5\xbd')
 
     def test_filter_out_none(self):
         data = {'a': 1, 'b': 2, 'c': None}


### PR DESCRIPTION
在python2环境里执行`str(u'你好')`是会抛出异常的。

`get_utf8_value()`的返回值只被`urllib.quote()`用到了，而`quote()`不能处理`u'你好'`。

所以只需要让`unicode`被转码成`utf-8`就够了。