### PR TITLE
perf: support python3.10+ version

### DIFF
--- a/qingcloud/conn/auth.py
+++ b/qingcloud/conn/auth.py
@@ -27,7 +27,11 @@ except:
     import urllib
     is_python3 = False
 
-from past.builtins import basestring
+if is_python3:
+    if sys.version_info.major >= 3 and sys.version_info.minor >= 10:
+        basestring = str
+else:
+    from past.builtins import basestring
 
 from qingcloud.misc.json_tool import json_dump, json_load
 from qingcloud.misc.utils import get_utf8_value, get_ts, base64_url_decode,\

--- a/qingcloud/iaas/lb_backend.py
+++ b/qingcloud/iaas/lb_backend.py
@@ -15,7 +15,11 @@
 # =========================================================================
 
 import json
-from past.builtins import basestring
+import sys
+if sys.version_info.major >= 3 and sys.version_info.minor >= 10:
+    basestring = str
+else:
+    from past.builtins import basestring
 
 
 class LoadBalancerBackend(object):


### PR DESCRIPTION
In Python 3.10+, the Iterable type has been moved to the collections.abc module. The `past` package,  which is used to provide Python 3 compatibility for Python 2 code, might not have been updated to reflect this change. 
```
if sys.version_info.major >= 3 and sys.version_info.minor >= 10:
    from collections.abc import Iterable
else:
    from collections import Iterable
```
I just monkey-patched the code.

Before the change,  the error message might have looked something like this:
```
  1 """
      2 Pure-Python implementation of a Python 2-like str object for Python 3.
      3 """
----> 5 from collections import Iterable
      6 from numbers import Integral
      8 from past.utils import PY2, with_metaclass

ImportError: cannot import name 'Iterable' from 'collections' 
``` 