### PR TITLE
fix: ModuleNotFoundError: no module named '__builtin__'

### DIFF
--- a/qingcloud/app/connection.py
+++ b/qingcloud/app/connection.py
@@ -1,7 +1,6 @@
 from qingcloud.iaas.connection import APIConnection
 from qingcloud.conn import auth
 from . import constants as const
-from __builtin__ import str
 
 
 class AppConnection(APIConnection):


### PR DESCRIPTION
`__builtin__` is renamed to `builtins` in [Python 3](https://docs.python.org/3/whatsnew/3.0.html). Besides that, we can directly use `str` in Python 2 and Python 3